### PR TITLE
feat: add CLI indexing and improve notes processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ bun install
 
 ## Usage
 
+### Option 1: Using Claude Desktop
+
 1. Open Claude desktop app and go to Settings -> Developer -> Edit Config
 
 ![Claude Desktop Settings](./images/desktop_settings.png)
@@ -61,6 +63,19 @@ Important: Replace `<YOUR_USER_NAME>` with your actual username.
 ![Claude MCP Connection Status](./images/verify_installation.png)
 
 4. Start by indexing your notes. Ask Claude to index your notes by saying something like: "Index my notes" or "Index my Apple Notes".
+
+### Option 2: Using CLI Directly
+
+You can also index your notes directly from the command line:
+
+```bash
+bun run index-notes
+```
+
+This will:
+1. Create/connect to the notes database
+2. Fetch and index all your Apple Notes
+3. Show progress and statistics about the indexing process
 
 ## Troubleshooting
 

--- a/cli.ts
+++ b/cli.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env bun
+import { createNotesTable, indexNotes } from "./index.js";
+
+async function main() {
+  console.log("🚀 Starting notes indexing process...\n");
+  
+  try {
+    console.log("📁 Creating/connecting to notes database...");
+    const { notesTable, time: setupTime } = await createNotesTable();
+    console.log(`✅ Database setup complete (${(setupTime / 1000).toFixed(2)}s)\n`);
+    
+    console.log("📝 Fetching notes from Apple Notes...");
+    const { chunks, time, allNotes, failed, report } = await indexNotes(notesTable);
+    
+    console.log("\n=== Indexing Complete ===");
+    console.log(`📊 Stats:`);
+    console.log(`• Total notes found: ${allNotes}`);
+    console.log(`• Successfully indexed: ${chunks} notes`);
+    console.log(`• Failed to process: ${failed} notes`);
+    console.log(`• Time taken: ${(time / 1000).toFixed(2)} seconds`);
+    
+    if (report.trim()) {
+      console.log("\n⚠️  Warnings/Issues:");
+      console.log(report);
+    }
+    
+    console.log("\n✨ Notes are now ready for semantic search!");
+  } catch (error) {
+    console.error("\n❌ Error while indexing notes:", error);
+    process.exit(1);
+  }
+}
+
+main(); 

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,17 +1,39 @@
 // Usage: npx tsx index.test.ts
-import { test, describe } from "node:test";
-import assert from "node:assert";
 import * as lancedb from "@lancedb/lancedb";
-import path from "node:path";
-import os from "node:os";
 import { LanceSchema } from "@lancedb/lancedb/embedding";
 import { Utf8 } from "apache-arrow";
+import assert from "node:assert";
+import os from "node:os";
+import path from "node:path";
+import { after, afterEach, beforeEach, describe, test } from "node:test";
 import {
   createNotesTable,
   indexNotes,
   OnDeviceEmbeddingFunction,
   searchAndCombineResults,
+  shutdown,
 } from "./index";
+
+async function* mockGetNotes() {
+  yield {
+    titles: ["Note 1", "Note 2", "Note 3"],
+    progress: {
+      current: 3,
+      total: 3,
+      batch: {
+        start: 1,
+        end: 3
+      }
+    }
+  };
+}
+
+const mockGetNoteDetails = async (title: string) => ({
+  title,
+  content: `Content for ${title}`,
+  creation_date: new Date().toISOString(),
+  modification_date: new Date().toISOString()
+});
 
 describe("Apple Notes Indexing", async () => {
   const db = await lancedb.connect(
@@ -27,8 +49,25 @@ describe("Apple Notes Indexing", async () => {
     vector: func.vectorField(),
   });
 
+  let originalGetNotes;
+  
+  beforeEach(() => {
+    // Store the original implementation
+    originalGetNotes = global.getNotes;
+  });
+
+  afterEach(() => {
+    // Restore the original implementation
+    global.getNotes = originalGetNotes;
+  });
+
+  // Add cleanup after all tests
+  after(async () => {
+    await shutdown();
+  });
+
   test("should create notes table", async () => {
-    const notesTable = await db.createEmptyTable("test-notes", notesSchema, {
+    const notesTable = await db.createEmptyTable("test-notes-" + Date.now(), notesSchema, {
       mode: "create",
       existOk: true,
     });
@@ -50,7 +89,7 @@ describe("Apple Notes Indexing", async () => {
 
   test("should perform vector search", async () => {
     const start = performance.now();
-    const { notesTable } = await createNotesTable("test-notes");
+    const { notesTable } = await createNotesTable("test-notes-" + Date.now());
     const end = performance.now();
     console.log(`Creating table took ${Math.round(end - start)}ms`);
 
@@ -77,11 +116,108 @@ describe("Apple Notes Indexing", async () => {
   });
 
   test("should perform vector search on real indexed data", async () => {
-    const { notesTable } = await createNotesTable("test-notes");
+    const { notesTable } = await createNotesTable("test-notes-" + Date.now());
+
+    // Add test data first
+    await notesTable.add([
+      {
+        id: "1",
+        title: "Test Note",
+        content: "This is a test note content with date 15/12",
+        creation_date: new Date().toISOString(),
+        modification_date: new Date().toISOString(),
+      },
+    ]);
 
     const results = await searchAndCombineResults(notesTable, "15/12");
 
     assert.ok(results.length > 0, "Should return search results");
     assert.equal(results[0].title, "Test Note", "Should find the test note");
+  });
+
+  test("should handle batched note processing", async () => {
+    const { notesTable } = await createNotesTable("test-notes-batch-" + Date.now());
+    
+    const result = await indexNotes(notesTable, {
+      getNotes: mockGetNotes,
+      getNoteDetailsByTitle: mockGetNoteDetails
+    });
+    
+    assert.ok(result.chunks >= 0, "Should report processed chunks");
+    assert.ok(result.failed >= 0, "Should report failed notes");
+    assert.ok(result.time > 0, "Should report processing time");
+    assert.ok(result.allNotes >= 0, "Should report total notes found");
+  });
+
+  test("should handle note processing timeouts", async () => {
+    const { notesTable } = await createNotesTable("test-notes-timeout-" + Date.now());
+    
+    const timeoutGetNoteDetails = async () => {
+      await new Promise(resolve => setTimeout(resolve, 100));
+      throw new Error('Simulated timeout');
+    };
+
+    const result = await indexNotes(notesTable, {
+      getNotes: async function* () {
+        yield {
+          titles: ["Very Long Note"],
+          progress: {
+            current: 1,
+            total: 1,
+            batch: {
+              start: 1,
+              end: 1
+            }
+          }
+        };
+      },
+      getNoteDetailsByTitle: timeoutGetNoteDetails
+    });
+    
+    assert.ok(result.failed > 0, "Should have failed notes");
+    assert.ok(result.report.includes("Error"), "Should include error reports");
+  });
+
+  test("should handle progress reporting", async () => {
+    const { notesTable } = await createNotesTable("test-notes-progress-" + Date.now());
+    
+    const testNotes = Array.from({ length: 5 }, (_, i) => ({
+      id: `progress-${i}`,
+      title: `Progress Test Note ${i}`,
+      content: `Content for note ${i}`,
+      creation_date: new Date().toISOString(),
+      modification_date: new Date().toISOString(),
+    }));
+    
+    await notesTable.add(testNotes);
+    
+    const result = await indexNotes(notesTable, {
+      getNotes: mockGetNotes,
+      getNoteDetailsByTitle: mockGetNoteDetails
+    });
+    
+    assert.ok(result.chunks >= 0, "Should process all test notes");
+    assert.ok(result.allNotes >= 0, "Should report total notes found");
+  });
+
+  test("should handle markdown conversion errors gracefully", async () => {
+    const { notesTable } = await createNotesTable("test-notes-markdown-" + Date.now());
+    
+    const problematicGetNoteDetails = async (title: string) => ({
+      title,
+      content: "<div><unclosed-tag>Bad HTML</div>", // Malformed HTML
+      creation_date: new Date().toISOString(),
+      modification_date: new Date().toISOString(),
+    });
+
+    const result = await indexNotes(notesTable, {
+      getNotes: mockGetNotes,
+      getNoteDetailsByTitle: problematicGetNoteDetails
+    });
+    
+    assert.ok(
+      result.report.includes("markdown") || result.report === "", 
+      "Should handle markdown conversion errors gracefully"
+    );
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -71,7 +71,7 @@ const GetNoteSchema = z.object({
   title: z.string(),
 });
 
-const server = new Server(
+export const server = new Server(
   {
     name: "my-apple-notes-mcp",
     version: "1.0.0",
@@ -82,6 +82,18 @@ const server = new Server(
     },
   }
 );
+
+// Add a shutdown method
+export const shutdown = async () => {
+  await db.close();
+  // Force cleanup of the pipeline
+  if (extractor) {
+    // @ts-ignore - accessing internal cleanup method
+    await extractor?.cleanup?.();
+  }
+  // Force exit since stdio transport doesn't have cleanup
+  process.exit(0);
+};
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
@@ -144,16 +156,91 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   };
 });
 
-const getNotes = async () => {
-  const notes = await runJxa(`
-    const app = Application('Notes');
-app.includeStandardAdditions = true;
-const notes = Array.from(app.notes());
-const titles = notes.map(note => note.properties().name);
-return titles;
-  `);
+const getNotes = async function* () {
+  console.log("   Requesting notes list from Apple Notes...");
+  try {
+    const BATCH_SIZE = 25;
+    let startIndex = 1;
+    let hasMore = true;
 
-  return notes as string[];
+    // First get the total count
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 60000);
+
+    const totalCount = await Promise.race([
+      runJxa(`
+        const app = Application('Notes');
+        app.includeStandardAdditions = true;
+        return app.notes().length;
+      `),
+      new Promise((_, reject) => {
+        controller.signal.addEventListener('abort', () => 
+          reject(new Error('Getting notes count timed out after 60s'))
+        );
+      })
+    ]) as number;
+
+    clearTimeout(timeout);
+    console.log(`   📊 Total notes found: ${totalCount}`);
+
+    while (hasMore) {
+      console.log(`   Fetching batch of notes (${startIndex} to ${startIndex + BATCH_SIZE - 1})...`);
+      
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 60000);
+
+      const batchResult = await Promise.race([
+        runJxa(`
+          const app = Application('Notes');
+          app.includeStandardAdditions = true;
+          
+          const titles = [];
+          for (let i = ${startIndex}; i < ${startIndex + BATCH_SIZE}; i++) {
+            try {
+              const note = app.notes[i - 1];
+              if (note) {
+                titles.push(note.name());
+              }
+            } catch (error) {
+              continue;
+            }
+          }
+          return titles;
+        `),
+        new Promise((_, reject) => {
+          controller.signal.addEventListener('abort', () => 
+            reject(new Error('Getting notes batch timed out after 60s'))
+          );
+        })
+      ]);
+
+      clearTimeout(timeout);
+      
+      const titles = batchResult as string[];
+      
+      // Yield the batch along with progress info
+      yield {
+        titles,
+        progress: {
+          current: startIndex + titles.length - 1,
+          total: totalCount,
+          batch: {
+            start: startIndex,
+            end: startIndex + BATCH_SIZE - 1
+          }
+        }
+      };
+      
+      startIndex += BATCH_SIZE;
+      hasMore = startIndex <= totalCount && titles.length > 0;
+
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+
+  } catch (error) {
+    console.error("   ❌ Error getting notes list:", error.message);
+    throw new Error(`Failed to get notes list: ${error.message}`);
+  }
 };
 
 const getNoteDetailsByTitle = async (title: string) => {
@@ -185,45 +272,104 @@ const getNoteDetailsByTitle = async (title: string) => {
   };
 };
 
-export const indexNotes = async (notesTable: any) => {
+export const indexNotes = async (
+  notesTable: any, 
+  deps = {
+    getNotes,
+    getNoteDetailsByTitle
+  }
+) => {
   const start = performance.now();
   let report = "";
-  const allNotes = (await getNotes()) || [];
-  const notesDetails = await Promise.all(
-    allNotes.map((note) => {
-      try {
-        return getNoteDetailsByTitle(note);
-      } catch (error) {
-        report += `Error getting note details for ${note}: ${error.message}\n`;
-        return {} as any;
-      }
-    })
-  );
+  let processed = 0;
+  let successful = 0;
+  let failed = 0;
+  let allNotes: string[] = [];
+  
+  console.log("📚 Getting and processing notes...");
+  
+  // Use injected dependencies instead of globals
+  for await (const batch of deps.getNotes()) {
+    allNotes = [...allNotes, ...batch.titles];
+    console.log(`\n📦 Processing batch of ${batch.titles.length} notes (${batch.progress.current}/${batch.progress.total})`);
+    
+    const batchResults = await Promise.all(
+      batch.titles.map(async (note) => {
+        try {
+          const controller = new AbortController();
+          const timeout = setTimeout(() => controller.abort(), 30000);
+          
+          try {
+            const result = await Promise.race([
+              deps.getNoteDetailsByTitle(note),
+              new Promise((_, reject) => {
+                controller.signal.addEventListener('abort', () => 
+                  reject(new Error('Note processing timed out after 30s'))
+                );
+              })
+            ]);
+            
+            clearTimeout(timeout);
+            processed++;
+            successful++;
+            
+            if (processed % 10 === 0 || processed === batch.progress.total) {
+              const progress = ((processed / batch.progress.total) * 100).toFixed(1);
+              console.log(`   Progress: ${processed}/${batch.progress.total} notes (${progress}%) | ✅ ${successful} | ❌ ${failed}`);
+            }
+            
+            return result;
+          } catch (error) {
+            clearTimeout(timeout);
+            throw error;
+          }
+        } catch (error) {
+          failed++;
+          report += `Error processing note "${note}": ${error.message}\n`;
+          return {} as any;
+        }
+      })
+    );
 
-  const chunks = notesDetails
-    .filter((n) => n.title)
-    .map((node) => {
-      try {
-        return {
-          ...node,
-          content: turndown(node.content || ""), // this sometimes fails
-        };
-      } catch (error) {
-        return node;
-      }
-    })
-    .map((note, index) => ({
-      id: index.toString(),
-      title: note.title,
-      content: note.content, // turndown(note.content || ""),
-      creation_date: note.creation_date,
-      modification_date: note.modification_date,
-    }));
+    console.log("📥 Converting batch to markdown format...");
+    const batchChunks = batchResults
+      .filter((n) => n.title)
+      .map((node) => {
+        try {
+          return {
+            ...node,
+            content: turndown(node.content || ""),
+          };
+        } catch (error) {
+          report += `Error converting note "${node.title}" to markdown: ${error.message}\n`;
+          return node;
+        }
+      })
+      .map((note, index) => ({
+        id: (processed - batch.titles.length + index).toString(),
+        title: note.title,
+        content: note.content,
+        creation_date: note.creation_date,
+        modification_date: note.modification_date,
+        // Remove vector field from the data we're adding
+        // vector: undefined
+      }));
 
-  await notesTable.add(chunks);
+    if (batchChunks.length > 0) {
+      console.log(`💾 Adding batch to database (${batchChunks.length} notes)...`);
+      try {
+        await notesTable.add(batchChunks);
+      } catch (error) {
+        report += `Error adding batch to database: ${error.message}\n`;
+        failed += batchChunks.length;
+        successful -= batchChunks.length;
+      }
+    }
+  }
 
   return {
-    chunks: chunks.length,
+    chunks: successful,
+    failed,
     report,
     allNotes: allNotes.length,
     time: performance.now() - start,
@@ -232,6 +378,8 @@ export const indexNotes = async (notesTable: any) => {
 
 export const createNotesTable = async (overrideName?: string) => {
   const start = performance.now();
+  
+  // Create a fresh table
   const notesTable = await db.createEmptyTable(
     overrideName || "notes",
     notesTableSchema,
@@ -383,3 +531,5 @@ const CreateNoteSchema = z.object({
   title: z.string(),
   content: z.string(),
 });
+
+export { db };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "bun build index.ts --outdir dist --target node",
     "start": "bun index.ts",
     "purge-db": "rm -rf ~/.mcp-apple-notes",
-    "test": "npx tsx index.test.ts"
+    "test": "npx tsx index.test.ts",
+    "index-notes": "bun cli.ts"
   },
   "exports": {
     ".": "./index.ts"


### PR DESCRIPTION
Context:

- I have ~3000 notes and it was just hanging
- I added batching with an async iterator and it works pretty well now

Changes:

- Add direct CLI command for indexing notes (`bun run index-notes`)
- Implement batched note processing to handle large collections
- Add timeout handling and progress reporting
- Improve error handling and recovery
- Add comprehensive test coverage for note processing
- Clean up database connections on shutdown