### PR TITLE
fix(jxa): pass title via args to prevent injection

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -159,22 +159,23 @@ return titles;
 const getNoteDetailsByTitle = async (title: string) => {
   const note = await runJxa(
     `const app = Application('Notes');
-    const title = "${title}"
-    
+    const title = args[0];
+
     try {
         const note = app.notes.whose({name: title})[0];
-        
+
         const noteInfo = {
             title: note.name(),
             content: note.body(),
             creation_date: note.creationDate().toLocaleString(),
             modification_date: note.modificationDate().toLocaleString()
         };
-        
+
         return JSON.stringify(noteInfo);
     } catch (error) {
         return "{}";
-    }`
+    }`,
+    [title]
   );
 
   return JSON.parse(note as string) as {


### PR DESCRIPTION
## Summary
- Note titles containing quotes or special characters (e.g. `"feature_limitation_rule": {`, `{"_id": "..."}`) break the JXA script because they're interpolated directly into the JavaScript string
- Fix: pass title via `run-jxa`'s `args` parameter instead of string interpolation, which safely handles any character in the title

## Test plan
- [x] Tested with 96 notes including titles with double quotes, backticks, curly braces, and JSON fragments
- [x] Verified `index-notes`, `get-note`, and `list-notes` all work after the fix